### PR TITLE
Change JSS peerDependency from 5.2.0 to ^5.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/cssinjs/react-jss",
   "peerDependencies": {
-    "jss": "5.2.0",
+    "jss": "^5.2.0",
     "react": ">=0.13"
   },
   "devDependencies": {


### PR DESCRIPTION
I can see no reason why the jss peer dep should be fixed at 5.2.0.