### PR TITLE
create JssSheetsRegistry component

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,41 @@ const Component = ({sheet: {classes}, children, isActive}) => (
 )
 ```
 
+### Using `JssSheetsRegistry` for server-side rendering
+
+```es6
+import {renderToString} from 'react-dom/server'
+import {SheetsRegistry} from 'jss'
+import {JssSheetsRegistry} from 'react-jss'
+import MyApp from './MyApp'
+
+export default function render(req, res) {
+  const sheets = new SheetsRegistry()
+
+  const body = renderToString(
+    <JssSheetsRegistry registry={sheets}>
+      <MyApp />
+    </JssSheetsRegistry>
+  )
+
+  // any instances of `injectStyle` within `<MyApp />` will have gotten `sheets`
+  // from `context` and added their style sheets to it by now.
+
+  return res.send(renderToString(
+    <html>
+      <head>
+        <style type="text/css">
+          {sheets.toString()}
+        </style>
+      </head>
+      <body>
+        {body}
+      </body>
+    </html>
+  ))
+}
+```
+
 ### Installation.
 
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-jss",
-  "version": "4.1.3",
+  "version": "4.2.0",
   "description": "Integration of JSS for react.",
   "main": "lib/index.js",
   "engines": {

--- a/src/JssSheetsRegistry.js
+++ b/src/JssSheetsRegistry.js
@@ -1,4 +1,4 @@
-import {Component, PropTypes} from 'react'
+import React, {Component, PropTypes, Children} from 'react'
 import {SheetsRegistry} from 'jss'
 
 export default class JssSheetsRegistry extends Component {
@@ -15,7 +15,12 @@ export default class JssSheetsRegistry extends Component {
     }
   }
   render() {
-    return this.props.children || null
+    const {children} = this.props
+    return (
+      Children.count(children) > 1
+        ? <div>{children}</div>
+        : children
+    )
   }
 }
 

--- a/src/JssSheetsRegistry.js
+++ b/src/JssSheetsRegistry.js
@@ -1,0 +1,21 @@
+import {Component, PropTypes} from 'react'
+import {SheetsRegistry} from 'jss'
+
+export default class JssSheetsRegistry extends Component {
+  static propTypes = {
+    registry: PropTypes.instanceOf(SheetsRegistry).isRequired,
+    children: PropTypes.node.isRequired
+  }
+  static childContextTypes = {
+    jssSheetsRegistry: PropTypes.instanceOf(SheetsRegistry).isRequired
+  }
+  getChildContext() {
+    return {
+      jssSheetsRegistry: this.props.registry
+    }
+  }
+  render() {
+    return this.props.children || null
+  }
+}
+

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,10 @@
-import React, {Component} from 'react'
-import {create as createJss} from 'jss'
+import React, {Component, PropTypes} from 'react'
+import {create as createJss, SheetsRegistry} from 'jss'
 import preset from 'jss-preset-default'
 import hoistNonReactStatics from 'hoist-non-react-statics'
+import JssSheetsRegistry from './JssSheetsRegistry'
+
+export {JssSheetsRegistry}
 
 /**
  * Wrap a Component into a JSS Container Component.
@@ -46,9 +49,14 @@ function wrap(jss, WrappedComponent, styles, options = {}) {
   return class Jss extends Component {
     static wrapped = WrappedComponent
     static displayName = `Jss(${displayName})`
+    static contextTypes = {
+      jssSheetsRegistry: PropTypes.instanceOf(SheetsRegistry)
+    }
 
     componentWillMount() {
       this.sheet = ref()
+      const {jssSheetsRegistry} = this.context
+      if (jssSheetsRegistry) jssSheetsRegistry.add(this.sheet)
     }
 
     componentWillUpdate() {
@@ -64,6 +72,8 @@ function wrap(jss, WrappedComponent, styles, options = {}) {
     componentWillUnmount() {
       if (this.sheet && !sheet && !refs) {
         this.sheet.detach()
+        const {jssSheetsRegistry} = this.context
+        if (jssSheetsRegistry) jssSheetsRegistry.remove(this.sheet)
       }
       else deref()
     }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -3,7 +3,7 @@ import jss, {create as createJss, SheetsRegistry} from 'jss'
 import React from 'react'
 import {render, unmountComponentAtNode} from 'react-dom'
 import deepForceUpdate from 'react-deep-force-update'
-import injectSheet, {create as createInjectSheet, jss as reactJss} from './'
+import injectSheet, {create as createInjectSheet, jss as reactJss, JssSheetsRegistry} from './'
 
 const node = document.createElement('div')
 
@@ -184,22 +184,25 @@ describe('react-jss', () => {
 
   describe('with JssSheetsRegistry', () => {
     it('should add style sheets to the registry from context', () => {
-      class AppContainer extends React.Component {
-        render() {
-          const sheets = new SheetsRegistry()
+      const sheets = new SheetsRegistry()
 
-          return (
-            <JssSheetsRegistry registry={sheets}>
-              <WrappedComponentA
-                {...this.props}
-                key={Math.random()} // Require children to unmount on every render
-              />
-            </JssSheetsRegistry>
-          )
+      const Component = () => null
+      const WrappedComponentA = injectSheet({
+        button: {color: 'red'}
+      })(Component)
+      const WrappedComponentB = injectSheet({
+        button: {color: 'blue'}
+      })(Component)
 
-          expect(sheets.registry.length).to.equal(2)
-        }
-      }
+      render(
+        <JssSheetsRegistry registry={sheets}>
+          <WrappedComponentA />
+          <WrappedComponentB />
+        </JssSheetsRegistry>,
+        node
+      )
+
+      expect(sheets.registry.length).to.equal(2)
     })
   })
 })

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,5 +1,5 @@
 import expect from 'expect.js'
-import jss, {create as createJss} from 'jss'
+import jss, {create as createJss, SheetsRegistry} from 'jss'
 import React from 'react'
 import {render, unmountComponentAtNode} from 'react-dom'
 import deepForceUpdate from 'react-deep-force-update'
@@ -179,6 +179,27 @@ describe('react-jss', () => {
 
       expect(document.querySelectorAll('style').length).to.be(1)
       expect(document.querySelectorAll('style')[0].innerHTML).to.contain('color: blue')
+    })
+  })
+
+  describe('with JssSheetsRegistry', () => {
+    it('should add style sheets to the registry from context', () => {
+      class AppContainer extends React.Component {
+        render() {
+          const sheets = new SheetsRegistry()
+
+          return (
+            <JssSheetsRegistry registry={sheets}>
+              <WrappedComponentA
+                {...this.props}
+                key={Math.random()} // Require children to unmount on every render
+              />
+            </JssSheetsRegistry>
+          )
+
+          expect(sheets.registry.length).to.equal(2)
+        }
+      }
     })
   })
 })


### PR DESCRIPTION
Note: this depends on https://github.com/cssinjs/jss/pull/355

It puts a `SheetsRegistry` from its props onto its child context as `jssSheetsRegistry`.

Then any `injectSheets` wrapper components check if `jssSheetsRegistry` is on their `context`, and if so, they add/remove their sheets from it.

I added a test and example usage for server-side rendering to the README.

Cheers!