### PR TITLE
Update react dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,9 +74,9 @@
     "lint-staged": "^3.0.3",
     "mocha": "^3.0.2",
     "pre-commit": "^1.1.3",
-    "react": ">=14.0.0 <=15.1.0",
+    "react": "^15.4.1",
     "react-deep-force-update": "^2.0.1",
-    "react-dom": "^15.3.2",
+    "react-dom": "^15.4.1",
     "rimraf": "^2.5.4",
     "webpack": "^1.13.1"
   },


### PR DESCRIPTION
@kof 

This was causing an issue because it was resulting in 2 incompatible react + react-dom versions to be installed from a fresh clone:

```
    "react": ">=14.0.0 <=15.1.0",
    "react-deep-force-update": "^2.0.1",
    "react-dom": "^15.3.2",
```

![image](https://cloud.githubusercontent.com/assets/4420103/21444669/34648d0a-c87e-11e6-8d7a-0e7b43b06287.png)


I've updated the dev dependencies for react to fix this