### PR TITLE
Pass classes directly to component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -80,7 +80,7 @@ function wrap(jss, WrappedComponent, stylesOrSheet, options = {}) {
     }
 
     render() {
-      return <WrappedComponent sheet={this.sheet} {...this.props} />
+      return <WrappedComponent sheet={this.sheet} classes={this.sheet.classes} {...this.props} />
     }
   }
 }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -105,6 +105,32 @@ describe('react-jss', () => {
     })
   })
 
+  describe('.injectSheet() classes prop', () => {
+    let passedClasses
+    let WrappedComponent
+
+    beforeEach(() => {
+      const Component = ({classes}) => {
+        passedClasses = classes
+        return null
+      }
+      WrappedComponent = injectSheet({
+        button: {color: 'red'}
+      })(Component)
+    })
+
+    it('should inject classes map as a prop', () => {
+      render(<WrappedComponent />, node)
+      expect(passedClasses).to.only.have.keys(['button'])
+    })
+
+    it('should not overwrite existing classes property', () => {
+      const classes = 'classes prop'
+      render(<WrappedComponent classes={classes} />, node)
+      expect(passedClasses).to.equal(classes)
+    })
+  })
+
   describe('.injectSheet() preserving source order', () => {
     let WrappedComponentA
     let WrappedComponentB


### PR DESCRIPTION
without the rest of the sheet object
closes #67

----

* [x] think, what happens when `this.sheet` is not defined
* [x] add tests on new functionality