### PR TITLE
proposal: combine classes passed into HoC with classes from injected sheet

### DIFF
--- a/src/createHoc.js
+++ b/src/createHoc.js
@@ -9,6 +9,18 @@ const refs = sheet => sheet[refNs] || 0
 const dec = sheet => --sheet[refNs]
 const inc = sheet => ++sheet[refNs]
 
+function combineClasses(sheet, classes) {
+  if (!sheet) sheet = {classes: {}}
+  if (!classes) return sheet.classes
+  const result = {}
+  for (let key in sheet.classes) {
+    result[key] = classes[key]
+      ? `${sheet.classes[key]} ${classes[key]}`
+      : sheet.classes[key]
+  }
+  return result
+}
+
 /**
  * Wrap a Component into a JSS Container Component.
  *
@@ -105,8 +117,9 @@ export default (jss, InnerComponent, stylesOrSheet, options = {}) => {
     }
 
     render() {
+      const {classes} = this.props
       const sheet = this.dynamicSheet || this.staticSheet
-      return <InnerComponent sheet={sheet} classes={sheet.classes} {...this.props} />
+      return <InnerComponent sheet={sheet} classes={combineClasses(sheet, classes)} {...this.props} />
     }
   }
 }


### PR DESCRIPTION
I have some private npm packages that export jss-styled components.  But those styles are only defaults, in my other packages I want to import those components and override some of the styles.

This PR should make it easy to do that (I haven't tested it yet):
```js
const styles = {
  foo: {...},
  bar: {...}
}

const StyledComp = injectSheet(styles)(MyComp)

// ... later, in another file/package:

import StyledComp from '...'

const additionalStyles = {
  foo: {...}
  bar: {...}
}

const RestyledComp = injectSheet(additionalStyles)(StyledComp)
```

With this PR the HoC will combine the input `classes` with the ones from `sheet`, and render:
```js
<MyComp classes={{
  foo: 'foo-<id1> foo-<id2>',
  bar: 'bar-<id3> bar-<id4>',
}} />
```
Where `id1`, `id2`, etc. are auto-generated ids.

I haven't double checked on whether I can rely on the ordering being correct so that everything overrides properly.  Need to do that.