### PR TITLE
Component to use manager in context, if a Provider has defined one

### DIFF
--- a/src/JssProvider.js
+++ b/src/JssProvider.js
@@ -27,6 +27,7 @@ export default class JssProvider extends Component {
         generateClassName: createGenerateClassName()
       },
       [ns.providerId]: Math.random(),
+      [ns.managers]: [],
       [ns.jss]: this.props.jss,
       [ns.sheetsRegistry]: this.props.registry
     }

--- a/src/contextTypes.js
+++ b/src/contextTypes.js
@@ -1,4 +1,4 @@
-import {object, number, instanceOf} from 'prop-types'
+import {object, number, instanceOf, array} from 'prop-types'
 import jss, {SheetsRegistry} from './jss'
 import * as ns from './ns'
 
@@ -6,5 +6,6 @@ export default {
   [ns.jss]: instanceOf(jss.constructor),
   [ns.sheetOptions]: object,
   [ns.sheetsRegistry]: instanceOf(SheetsRegistry),
+  [ns.managers]: array,
   [ns.providerId]: number
 }

--- a/src/createHoc.js
+++ b/src/createHoc.js
@@ -50,8 +50,8 @@ export default (stylesOrCreator, InnerComponent, options = {}) => {
   const {themeListener} = theming
   const displayName = `Jss(${getDisplayName(InnerComponent)})`
   const noTheme = {}
-  let manager = new SheetsManager()
-  let providerId
+  const managerId = Math.random()
+  const manager = new SheetsManager()
 
   return class Jss extends Component {
     static displayName = displayName
@@ -74,10 +74,12 @@ export default (stylesOrCreator, InnerComponent, options = {}) => {
     }
 
     get manager() {
-      if (providerId && this.context[ns.providerId] !== providerId) {
-        manager = new SheetsManager()
+      if (this.context[ns.managers]) {
+        if (!this.context[ns.managers][managerId]) {
+          this.context[ns.managers][managerId] = new SheetsManager()
+        }
+        return this.context[ns.managers][managerId]
       }
-      providerId = this.context[ns.providerId]
 
       return manager
     }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
 export {ThemeProvider, withTheme, createTheming} from 'theming'
 export {default as JssProvider} from './JssProvider'
-export {default as jss, SheetsRegistry} from './jss'
+export {default as jss, SheetsRegistry, SheetsManager} from './jss'
 export {default} from './injectSheet'

--- a/src/ns.js
+++ b/src/ns.js
@@ -4,4 +4,5 @@
 export const jss = '64a55d578f856d258dc345b094a2a2b3'
 export const sheetsRegistry = 'd4bd0baacbc52bbd48bbb9eb24344ecd'
 export const providerId = 'd9f144a51454eae08eb84ab3ade674a5'
+export const managers = 'b768b78919504fba9de2c03545c5cd3a'
 export const sheetOptions = '6fc570d6bd61383819d0f9e7407c452d'


### PR DESCRIPTION
This is to allow multiple contexts to coexist. Alternate to #148 