### PR TITLE
fix(createHoc): don't copy defaultProps from wrapped component

### DIFF
--- a/src/createHoc.js
+++ b/src/createHoc.js
@@ -60,7 +60,6 @@ export default (stylesOrCreator, InnerComponent, options = {}) => {
       ...contextTypes,
       ...(isThemingEnabled && themeListener.contextTypes)
     }
-    static defaultProps = InnerComponent.defaultProps
 
     constructor(props, context) {
       super(props, context)


### PR DESCRIPTION
fix #152