### PR TITLE
Setting new context to instance of createHoc in componentWillReceiveProps

### DIFF
--- a/src/createHoc.js
+++ b/src/createHoc.js
@@ -176,7 +176,7 @@ export default (stylesOrCreator, InnerComponent, options = {}) => {
     }
 
     componentWillReceiveProps(nextProps, newContext) {
-      this.context = newContext;
+      this.context = newContext
       const {dynamicSheet} = this.state
       if (dynamicSheet) dynamicSheet.update(nextProps)
     }

--- a/src/createHoc.js
+++ b/src/createHoc.js
@@ -175,7 +175,8 @@ export default (stylesOrCreator, InnerComponent, options = {}) => {
       }
     }
 
-    componentWillReceiveProps(nextProps) {
+    componentWillReceiveProps(nextProps, newContext) {
+      this.context = newContext;
       const {dynamicSheet} = this.state
       if (dynamicSheet) dynamicSheet.update(nextProps)
     }

--- a/src/injectSheet.test.js
+++ b/src/injectSheet.test.js
@@ -282,9 +282,8 @@ describe('injectSheet', () => {
       const ThemeA = {color: "blue"};
       const ThemeB = {color: "red"};
       const ComponentA = injectSheet(() => ({a: {left: 2}}))()
-      const localJss = create()
       render((
-        <JssProvider jss={localJss}>
+        <JssProvider jss={jss}>
           <ThemeProvider theme={ThemeA}>
             <div>
               <ComponentA />
@@ -299,7 +298,7 @@ describe('injectSheet', () => {
       const actual = styleTags.map(innerText).map(trim).join('\n')
   
       expect(actual).to.be(stripIndent`
-      .NoRenderer-a-1-1 {
+      .a-id {
         left: 2;
       }
       `)
@@ -312,12 +311,7 @@ describe('injectSheet', () => {
           }
         }
       }
-      const newJss = createJss({
-        createGenerateClassName: () => {
-          let counter = 0
-          return rule => `${rule.key}-${counter++}`
-        }
-      })
+      const newJss = createJss({createGenerateClassName})
       newJss.use(rtl())
       render((
         <JssProvider jss={newJss}>
@@ -334,7 +328,7 @@ describe('injectSheet', () => {
       const newActual = newStyleTags.map(newInnerText).map(newTrim).join('\n')
   
       expect(newActual).to.be(stripIndent`
-      .NoRenderer-a-1-2 {
+      .a-id {
         right: 2px;
       }
       `)

--- a/src/injectSheet.test.js
+++ b/src/injectSheet.test.js
@@ -7,7 +7,6 @@ import getDisplayName from './getDisplayName'
 import createHoc from './createHoc'
 import {createGenerateClassName} from '../tests/helper'
 import {stripIndent} from 'common-tags'
-import preset from 'jss-preset-default'
 
 describe('injectSheet', () => {
   let jss
@@ -283,13 +282,7 @@ describe('injectSheet', () => {
       const ThemeA = {color: "blue"};
       const ThemeB = {color: "red"};
       const ComponentA = injectSheet(() => ({a: {left: 2}}))()
-      const localJss = createJss({
-        ...preset(),
-        createGenerateClassName: () => {
-          let counter = 0
-          return rule => `${rule.key}-${counter++}`
-        }
-      })
+      const localJss = create()
       render((
         <JssProvider jss={localJss}>
           <ThemeProvider theme={ThemeA}>
@@ -306,9 +299,9 @@ describe('injectSheet', () => {
       const actual = styleTags.map(innerText).map(trim).join('\n')
   
       expect(actual).to.be(stripIndent`
-        .a-0 {
-          left: 2px;
-        }
+      .NoRenderer-a-1-1 {
+        left: 2;
+      }
       `)
       function rtl() {
         return {
@@ -320,7 +313,6 @@ describe('injectSheet', () => {
         }
       }
       const newJss = createJss({
-        ...preset(),
         createGenerateClassName: () => {
           let counter = 0
           return rule => `${rule.key}-${counter++}`
@@ -342,9 +334,9 @@ describe('injectSheet', () => {
       const newActual = newStyleTags.map(newInnerText).map(newTrim).join('\n')
   
       expect(newActual).to.be(stripIndent`
-        .a-1 {
-          right: 2px;
-        }
+      .NoRenderer-a-1-2 {
+        right: 2px;
+      }
       `)
     })
   

--- a/src/tests/theming.js
+++ b/src/tests/theming.js
@@ -328,20 +328,20 @@ describe('theming', () => {
     function rtl() {
       return {
         onProcessStyle(style, rule, sheet) {
-        return {
-          right: "2px"
+          return {
+            right: '2px'
+          }
         }
       }
     }
-  }
-  const newJss = createJss({
-    ...preset(),
-    createGenerateClassName: () => {
-      let counter = 0
-      return rule => `${rule.key}-${counter++}`
-    }
-  })
-  newJss.use(rtl())
+    const newJss = createJss({
+      ...preset(),
+      createGenerateClassName: () => {
+        let counter = 0
+        return rule => `${rule.key}-${counter++}`
+      }
+    })
+    newJss.use(rtl())
     render((
       <JssProvider jss={newJss}>
         <ThemeProvider theme={ThemeB}>
@@ -356,12 +356,11 @@ describe('theming', () => {
     const newTrim = x => x.trim()
     const newActual = newStyleTags.map(newInnerText).map(newTrim).join('\n')
 
-    expect(actual).to.be(stripIndent`
-      .a-0 {
+    expect(newActual).to.be(stripIndent`
+      .a-1 {
         right: 2px;
       }
     `)
-
   })
 
   it('should render two different sheets with theming', () => {

--- a/src/tests/theming.js
+++ b/src/tests/theming.js
@@ -303,6 +303,66 @@ describe('theming', () => {
       }
     `)
   })
+  it('setState should use new context', () => {
+    const ComponentA = injectSheet(() => ({a: {left: 2}}))()
+    render((
+      <JssProvider jss={localJss}>
+        <ThemeProvider theme={ThemeA}>
+          <div>
+            <ComponentA />
+          </div>
+        </ThemeProvider>
+      </JssProvider>
+    ), node)
+
+    const styleTags = Array.from(document.querySelectorAll('style'))
+    const innerText = x => x.innerText
+    const trim = x => x.trim()
+    const actual = styleTags.map(innerText).map(trim).join('\n')
+
+    expect(actual).to.be(stripIndent`
+      .a-0 {
+        left: 2px;
+      }
+    `)
+    function rtl() {
+      return {
+        onProcessStyle(style, rule, sheet) {
+        return {
+          right: "2px"
+        }
+      }
+    }
+  }
+  const newJss = createJss({
+    ...preset(),
+    createGenerateClassName: () => {
+      let counter = 0
+      return rule => `${rule.key}-${counter++}`
+    }
+  })
+  newJss.use(rtl())
+    render((
+      <JssProvider jss={newJss}>
+        <ThemeProvider theme={ThemeB}>
+          <div>
+            <ComponentA />
+          </div>
+        </ThemeProvider>
+      </JssProvider>
+    ), node)
+    const newStyleTags = Array.from(document.querySelectorAll('style'))
+    const newInnerText = x => x.innerText
+    const newTrim = x => x.trim()
+    const newActual = newStyleTags.map(newInnerText).map(newTrim).join('\n')
+
+    expect(actual).to.be(stripIndent`
+      .a-0 {
+        right: 2px;
+      }
+    `)
+
+  })
 
   it('should render two different sheets with theming', () => {
     const ComponentA = injectSheet(() => ({a: {color: 'red'}}))()

--- a/src/tests/theming.js
+++ b/src/tests/theming.js
@@ -303,65 +303,6 @@ describe('theming', () => {
       }
     `)
   })
-  it('setState should use new context', () => {
-    const ComponentA = injectSheet(() => ({a: {left: 2}}))()
-    render((
-      <JssProvider jss={localJss}>
-        <ThemeProvider theme={ThemeA}>
-          <div>
-            <ComponentA />
-          </div>
-        </ThemeProvider>
-      </JssProvider>
-    ), node)
-
-    const styleTags = Array.from(document.querySelectorAll('style'))
-    const innerText = x => x.innerText
-    const trim = x => x.trim()
-    const actual = styleTags.map(innerText).map(trim).join('\n')
-
-    expect(actual).to.be(stripIndent`
-      .a-0 {
-        left: 2px;
-      }
-    `)
-    function rtl() {
-      return {
-        onProcessStyle(style, rule, sheet) {
-          return {
-            right: '2px'
-          }
-        }
-      }
-    }
-    const newJss = createJss({
-      ...preset(),
-      createGenerateClassName: () => {
-        let counter = 0
-        return rule => `${rule.key}-${counter++}`
-      }
-    })
-    newJss.use(rtl())
-    render((
-      <JssProvider jss={newJss}>
-        <ThemeProvider theme={ThemeB}>
-          <div>
-            <ComponentA />
-          </div>
-        </ThemeProvider>
-      </JssProvider>
-    ), node)
-    const newStyleTags = Array.from(document.querySelectorAll('style'))
-    const newInnerText = x => x.innerText
-    const newTrim = x => x.trim()
-    const newActual = newStyleTags.map(newInnerText).map(newTrim).join('\n')
-
-    expect(newActual).to.be(stripIndent`
-      .a-1 {
-        right: 2px;
-      }
-    `)
-  })
 
   it('should render two different sheets with theming', () => {
     const ComponentA = injectSheet(() => ({a: {color: 'red'}}))()


### PR DESCRIPTION
In the code for updateClassInstance method in react-dom.development.js file, first
all the lifecycle methods like componentWillReceiveProps, componentWillUpdate,
shouldComponentUpdate are called and in the end of updateClassInstance,
instance.context is set to new context.. so problem here is that in createHoc's
componentWillReceiveProps createState is called which in turn references this.context.
so this will always reference the old context. Since componentWillReceiveProps is
the first method in update cycle.. setting the context in this instance to newContext.