### PR TITLE
enhancing inject option to inject only part of theme as prop

### DIFF
--- a/src/createHoc.js
+++ b/src/createHoc.js
@@ -40,10 +40,22 @@ const getStyles = (stylesOrCreator, theme) => {
 
 // Returns an object with array property as a key and true as a value.
 const toMap = arr => arr.reduce((map, prop) => {
-  map[prop] = true
+  if (typeof prop === 'object' && prop.themeProps) {
+    map.themeProps = prop.themeProps
+  }
+  else {
+    map[prop] = true
+  }
   return map
 }, {})
-
+const getRequiredThemeProps = (object, property) => {
+  if (object && typeof object == 'object') {
+    if (typeof property == 'string' && property !== '') {
+      const split = property.split('.')
+      return split.reduce((obj, prop) => obj && obj[prop], object)
+    }
+  }
+}
 const defaultInjectProps = {
   sheet: false,
   classes: true,
@@ -214,6 +226,12 @@ export default (stylesOrCreator, InnerComponent, options = {}) => {
       const props = {}
       if (injectMap.sheet) props.sheet = sheet
       if (isThemingEnabled && injectMap.theme) props.theme = theme
+      if (isThemingEnabled && injectMap.themeProps) {
+        const ThemeProps = getRequiredThemeProps(theme, injectMap.themeProps)
+        if (typeof ThemeProps === 'object') {
+          Object.assign(props, ThemeProps)
+        }
+      }
       Object.assign(props, this.props)
       // We have merged classes already.
       if (injectMap.classes) props.classes = classes

--- a/src/injectSheet.test.js
+++ b/src/injectSheet.test.js
@@ -70,7 +70,7 @@ describe('injectSheet', () => {
   })
 
   describe('injectSheet() option "inject"', () => {
-    const getInjected = (options) => {
+    const getInjected = (options, theme = {}, props = {}, bReturnPropsObject = false) => {
       let injectedProps
       const Renderer = (props) => {
         injectedProps = props
@@ -79,8 +79,8 @@ describe('injectSheet', () => {
       const MyComponent = injectSheet(() => ({
         button: {color: 'red'}
       }), options)(Renderer)
-      render(<ThemeProvider theme={{}}><MyComponent /></ThemeProvider>, node)
-      return Object.keys(injectedProps)
+      render(<ThemeProvider theme={theme}><MyComponent {...props} /></ThemeProvider>, node)
+      return bReturnPropsObject ? injectedProps : Object.keys(injectedProps)
     }
 
     it('should inject all by default', () => {
@@ -101,6 +101,16 @@ describe('injectSheet', () => {
 
     it('should inject classes and theme', () => {
       expect(getInjected({inject: ['classes', 'theme']})).to.eql(['theme', 'classes'])
+    })
+    it('should inject themeProps', () => {
+      expect(getInjected({inject: ['classes', {themeProps: 'ButtonBase'}]}, {color: 'red', ButtonBase: {height: 10}})).to.eql(['height', 'classes'])
+    })
+    it('should not break and inject classes', () => {
+      expect(getInjected({inject: ['classes', {themeProps: 'Button'}]}, {color: 'red', ButtonBase: {height: 10}})).to.eql(['classes'])
+    })
+    it('should override themeProps with prop passed to component', () => {
+      const heightProp = getInjected({inject: ['classes', {themeProps: 'ButtonBase'}]}, {color: 'red', ButtonBase: {height: 10}}, {height: 20}, true).height
+      expect(heightProp).to.eql(20)
     })
   })
 


### PR DESCRIPTION
By default theme is injected as prop to component. But in the options to injectSheet
we can whitelist props to be injected with 'inject' property. However, if we want to inject only some part
of theme as prop there is no way. So adding one more key to inject option to give
the flexibility to inject only part of theme. 
So lets take an example component where we are consuming a property 'height' and we want to provide flexibility where property can directly be passed to the component or at a global level as part of theme so that all component instances will get the same value for that property. 
```javascript
const Example = props => {
const height = props.height || props.theme.ButtonBase.height; //give priority to props.height
//as it is passed specific to this instance
  return <div> value of height is {height} </div>;
};
```
While this works, there are two problems with this approach: 

1. Entire theme object is passed to the component which might be huge and the component required
only few of the properties.
2. For each of the property that we are allowing to be defined in theme, we will end up writing code
like:
```javascript
props.height || props.theme.ButtonBase.height
```
which makes the code look ugly and difficult to maintain.

By providing the provision to inject only part of theme as prop to the component, we solve
both of the above problems. Only required properties will be injected making props
object small.
Secondly, for each property  we just need to consume it like:
```javascript
props.height
```
and createHoc takes care of overriding theme passed prop if prop is passed to component
instance and it makes the code look independent of theme and easy to maintain.
One more advantage of extending inject option to provide what property to inject still
keeps react-jss code unaware of theme object and independent of it.

With this change we extend inject option to accept an object as well as one of the elements in the array with key 'themeProps' and its value will be the property path of the part required to be injected in the component as prop.

**Sample Usage:**
```javascript
const styles = {
color: 'red'
}
const Example = props => {
  const height = props.height;
  return <div> value of height is {height} </div>;
};
export injectSheet(styles, {inject: ['classes', {themeProps: 'ButtonBase'}]})(Example)
//and if we render this Example component wrapped with ThemeProvider:
<ThemeProvider theme={{color: 'blue', ButtonBase: {height: 10, width:20}}}><Example /> </ThemeProvider>
//height and width will be injected to props of Example
//Output will be: value of height is 10
```
Property passed to component instance will override property passed by theme:
```javascript
export injectSheet(styles, {inject: ['classes', {themeProps: 'ButtonBase'}]})(Example)
<ThemeProvider theme={{color: 'blue', ButtonBase: {height: 10, width:20}}}><Example height=30/> </ThemeProvider>
//width and height will be injected to props of Example
//output will be: value of height is 20
```
We can also pass path of a nested property in theme object to be injected as prop:
```javascript
export injectSheet(styles, {inject: ['classes', {themeProps: 'a.b.c'}]})(Example)
//so if theme object look like:
  theme = {
    color: 'red',
    a: {
      b: {
        c: {
          p: 10,
          q: 20
        }
      }
    }
  }
//p and q will be injected to props of Example.
```

