### PR TITLE
 Introducing reduceProps functionality replacing inject option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -386,18 +386,34 @@ const Button = injectSheet(buttonStyles)(() => <button><Label>my button</Label><
 ## Whitelist injected props
 
 By default "classes" and "theme" are going to be injected to the child component over props. Property `theme` is only passed when you use a function instead of styles object.
-If you want to whitelist some of them, you can now use option `inject`. For e.g. if you want to access the StyleSheet instance, you need to pass `{inject: ['sheet']}` and it will be available as `props.sheet`.
-
-All user props passed to the HOC will still be forwarded as usual.
+If you want to whitelist some of them, you can now use option `reduceProps` and pass a function to it which should return the props to be injected to child component. For e.g. if you want to access only the StyleSheet instance and props passed to the component, you need to pass `{reduceProps: ({sheet, theme,classes, ...rest}) => {return {sheet, ...rest}}}` and it will be available as `props.sheet`.
 
 ```js
 
-// Only `classes` prop will be passed by the ReactJSS HOC now. No `sheet` or `theme`.
-const Button = injectSheet(styles, {inject: ['classes', 'sheet']})(
+// Only `classes` and props passed to component will be passed by the ReactJSS HOC now. No `sheet` or `theme`.
+const Button = injectSheet(styles, {reduceProps: ({sheet, classes, theme, ...rest}) => {return {classes, ...rest}}})(
   ({classes}) => <button>My button</button>
 )
 ```
-
+To whitelist at a global level for all instances of injectSheet wrapped inside a JssProvider, you can pass `reduceProps` prop to JssProvider as follows:
+```js
+const styles = {
+color: 'red'
+}
+const reduceProps = (props) => {
+   const {theme, classes, sheet, ...rest} = props
+    return {classes, ...theme.ButtonBase, ...rest}
+ }
+const Example = props => {
+  const height = props.height;
+  return <div> value of height is {height} </div>;
+};
+export injectSheet(styles)(Example)
+//and if we render this Example component wrapped with JssProvider:
+<JssProvider reduceProps={reduceProps}><ThemeProvider theme={{color: 'blue', ButtonBase: {height: 10, width:20}}}><Example /> </ThemeProvider></JssProvider>
+//height and width will be injected to props of Example
+//Output will be: value of height is 10
+```
 ## Contributing
 
 See our [contribution guidelines](./contributing.md).

--- a/src/JssProvider.js
+++ b/src/JssProvider.js
@@ -9,6 +9,7 @@ export default class JssProvider extends Component {
   static propTypes = {
     ...propTypes,
     generateClassName: func,
+    reduceProps: func,
     classNamePrefix: string,
     children: node.isRequired
   }
@@ -22,7 +23,7 @@ export default class JssProvider extends Component {
   // 2. If value was passed, we set it on the child context.
   // 3. If value was not passed, we proxy parent context (default context behaviour).
   getChildContext() {
-    const {registry, classNamePrefix, jss: localJss, generateClassName} = this.props
+    const {registry, classNamePrefix, jss: localJss, generateClassName, reduceProps} = this.props
     const sheetOptions = this.context[ns.sheetOptions] || {}
     const context = {[ns.sheetOptions]: sheetOptions}
 
@@ -59,6 +60,7 @@ export default class JssProvider extends Component {
     }
 
     if (classNamePrefix) sheetOptions.classNamePrefix = classNamePrefix
+    if (reduceProps) sheetOptions.reduceProps = reduceProps
     if (localJss) context[ns.jss] = localJss
 
     return context

--- a/src/JssProvider.test.js
+++ b/src/JssProvider.test.js
@@ -290,8 +290,8 @@ describe('JssProvider', () => {
 
     it('should use Jss istance from the context', () => {
       let receivedSheet
-
-      const MyComponent = injectSheet({}, {inject: ['sheet']})(({sheet}) => {
+      const reduceProps = ({sheet}) => ({sheet})
+      const MyComponent = injectSheet({}, {reduceProps})(({sheet}) => {
         receivedSheet = sheet
         return null
       })

--- a/src/createHoc.js
+++ b/src/createHoc.js
@@ -56,7 +56,7 @@ let managersCounter = 0
  */
 export default (stylesOrCreator, InnerComponent, options = {}) => {
   const isThemingEnabled = typeof stylesOrCreator === 'function'
-  const {theming = defaultTheming, jss: optionsJss, reduceProps, ...sheetOptions} = options
+  const {theming = defaultTheming, jss: optionsJss, ...sheetOptions} = options
   const injectMap = defaultInjectProps
   const {themeListener} = theming
   const displayName = getDisplayName(InnerComponent)
@@ -205,6 +205,10 @@ export default (stylesOrCreator, InnerComponent, options = {}) => {
     render() {
       const {theme, dynamicSheet, classes} = this.state
       const sheet = dynamicSheet || this.manager.get(theme)
+      let {reduceProps} = sheetOptions
+      if (typeof reduceProps !== 'function' && this.context[ns.sheetOptions] && this.context[ns.sheetOptions].reduceProps) {
+        reduceProps = this.context[ns.sheetOptions].reduceProps
+      }
       const props = {}
       if (typeof reduceProps === 'function') {
         const propsToBeReduced = {}

--- a/src/injectSheet.js
+++ b/src/injectSheet.js
@@ -29,11 +29,6 @@ export default function injectSheet(stylesOrSheet, options = {}) {
     options.index = indexCounter++
   }
   return (InnerComponent = NoRenderer) => {
-    const {reduceProps} = options
-    // if reduceProps is not in options, check if static property for the function is set
-    if (typeof reduceProps !== 'function' && typeof injectSheet.reduceProps === 'function') {
-      options.reduceProps = injectSheet.reduceProps
-    }
     const Jss = createHoc(stylesOrSheet, InnerComponent, options)
     return hoistNonReactStatics(Jss, InnerComponent, {inner: true})
   }

--- a/src/injectSheet.js
+++ b/src/injectSheet.js
@@ -29,6 +29,11 @@ export default function injectSheet(stylesOrSheet, options = {}) {
     options.index = indexCounter++
   }
   return (InnerComponent = NoRenderer) => {
+    const {reduceProps} = options
+    // if reduceProps is not in options, check if static property for the function is set
+    if (typeof reduceProps !== 'function' && typeof injectSheet.reduceProps === 'function') {
+      options.reduceProps = injectSheet.reduceProps
+    }
     const Jss = createHoc(stylesOrSheet, InnerComponent, options)
     return hoistNonReactStatics(Jss, InnerComponent, {inner: true})
   }

--- a/src/injectSheet.test.js
+++ b/src/injectSheet.test.js
@@ -127,16 +127,23 @@ describe('injectSheet', () => {
       })
       expect(getInjected({reduceProps}, {color: 'red', ButtonBase: {height: 10}})).to.eql(['sheet', 'height', 'classes'])
     })
-    it('should reduce props with static function', () => {
-      injectSheet.reduceProps = ({sheet, theme, classes, ...rest}) => ({
+    it('should reduce props with reduceProp passed to JssProvider', () => {
+      const reduceProps = ({sheet, theme, classes, ...rest}) => ({
         ...rest,
         sheet,
         ...theme.ButtonBase,
         classes
       })
-      const heightProp = getInjected({}, {color: 'red', ButtonBase: {height: 10}}, {}, true).height
-      expect(heightProp).to.eql(10)
-      injectSheet.reduceProps = undefined
+      let injectedProps
+      const Renderer = (props) => {
+        injectedProps = props
+        return null
+      }
+      const MyComponent = injectSheet(() => ({
+        button: {color: 'red'}
+      }))(Renderer)
+      render(<JssProvider reduceProps={reduceProps}><ThemeProvider theme={{color: 'red', ButtonBase: {height: 10}}}><MyComponent /></ThemeProvider></JssProvider>, node)
+      expect(injectedProps.height).to.eql(10)
     })
     it('should override themeProps with prop passed to component', () => {
       const reduceProps = ({sheet, theme, classes, ...rest}) => ({


### PR DESCRIPTION
react-jss had one option called 'inject' which was used to whitelist properties injected by injectSheet to the child component:

```javascript
// Only `classes` prop will be passed by the ReactJSS HOC now. No `sheet` or `theme`.
const Button = injectSheet(styles, {inject: ['classes', 'sheet']})(
  ({classes}) => <button>My button</button>
)
```
However, if we want to inject only some part
of theme as prop there is no way. So adding one more key to inject option to give
the flexibility to inject only part of theme. 
So lets take an example component where we are consuming a property 'height' and we want to provide flexibility where property can directly be passed to the component or at a global level as part of theme so that all component instances will get the same value for that property. 
```javascript
const Example = props => {
const height = props.height || props.theme.ButtonBase.height; //give priority to props.height
//as it is passed specific to this instance
  return <div> value of height is {height} </div>;
};
```
While this works, there are two problems with this approach: 

1. Entire theme object is passed to the component which might be huge and the component required
only few of the properties.
2. For each of the property that we are allowing to be defined in theme, we will end up writing code
like:
```javascript
props.height || props.theme.ButtonBase.height
```
which makes the code look ugly and difficult to maintain.

With this change, we replace inject option with another option called 'reduceProps' whose value should be a function that should return the props to be injected.

By providing the provision to inject only part of theme as prop to the component, we solve
both of the above problems. Only required properties will be injected making props
object small.
Secondly, for each property  we just need to consume it like:
```javascript
props.height
```
and createHoc takes care of overriding theme passed prop if prop is passed to component
instance and it makes the code look independent of theme and easy to maintain.

**Sample Usage**
```javascript
const styles = {
color: 'red'
}
const Example = props => {
  return <div className={props.classes.hello}> Hello </div>;
};
const reduceProps = (props) => {
   const {theme, classes, sheet, ...rest} = props
    return {theme, classes, ...rest}
 }
export injectSheet(styles, {reduceProps})(Example)
```
So, with this change user can write any function and decide what properties should go to the child component. Not just for whitelisting some properties like theme, classes, sheet. But we can even whitelist some properties within these objects:

```javascript
const styles = {
color: 'red'
}
const reduceProps = (props) => {
   const {theme, classes, sheet, ...rest} = props
    return {classes, ...theme.ButtonBase, ...rest}
 }
const Example = props => {
  const height = props.height;
  return <div> value of height is {height} </div>;
};
export injectSheet(styles, {reduceProps })(Example)
//and if we render this Example component wrapped with ThemeProvider:
<ThemeProvider theme={{color: 'blue', ButtonBase: {height: 10, width:20}}}><Example /> </ThemeProvider>
//height and width will be injected to props of Example
//Output will be: value of height is 10
```
reduceProps function can also be set a global level by passing a prop to the JssProvider:
```javascript
const styles = {
color: 'red'
}
//only thene and classes will be injected
const reduceProps = (props) => {
   const {theme, classes, sheet, ...rest} = props
    return {classes, ...theme.ButtonBase, ...rest}
 }
const Example = props => {
  const height = props.height;
  return <div> value of height is {height} </div>;
};
export injectSheet(styles)(Example)
//and if we render this Example component wrapped with JssProvider:
<JssProvider reduceProps={reduceProps}><ThemeProvider theme={{color: 'blue', ButtonBase: {height: 10, width:20}}}><Example /> </ThemeProvider></JssProvider>
//height and width will be injected to props of Example
//Output will be: value of height is 10
```