### PR TITLE
Update dependency to 2.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "webpack": "^1.13.1"
   },
   "dependencies": {
-    "hoist-non-react-statics": "^2.3.1",
+    "hoist-non-react-statics": "^2.5.0",
     "jss": "^9.7.0",
     "jss-preset-default": "^4.3.0",
     "prop-types": "^15.6.0",


### PR DESCRIPTION
I want to update 'hoist-non-react-statics' dependency in order to allow working with React 16.3 version and new lifecycle methods.