### PR TITLE
Added disabling of styles generation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,7 @@ Benefits compared to lower level core:
   * [Dynamic Values](#dynamic-values)
   * [Theming](#theming)
   * [Server-side rendering](#server-side-rendering)
+  * [React tree traversing](#react-tree-traversing)
   * [Reuse styles in different components](#reuse-styles-in-different-components)
   * [The inner component](#the-inner-component)
   * [The inner ref](#the-inner-ref)
@@ -326,6 +327,33 @@ export default function render(req, res) {
     </html>
   ))
 }
+```
+
+### React tree traversing
+
+For traversing the React tree outside of the HTML rendering, you should add `disableStylesGeneration` property.
+
+```javascript
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import bootstrapper from 'react-async-bootstrapper';
+
+import { JssProvider } from 'react-jss';
+import MyApp from './MyApp';
+
+const App = ({ disableStylesGeneration }) => (
+  <JssProvider disableStylesGeneration>
+    <MyApp />
+  </JssProvider>
+);
+
+async function main() {
+  await bootstrapper(<App disableStylesGeneration />);
+  ReactDOM.render(<App />, document.getElementById('root'));
+}
+
+main();
+
 ```
 
 ### Reuse styles in different components

--- a/src/JssProvider.js
+++ b/src/JssProvider.js
@@ -1,5 +1,5 @@
 import {Component, Children} from 'react'
-import {node, func, string} from 'prop-types'
+import {node, func, string, bool} from 'prop-types'
 import {createGenerateClassNameDefault} from './jss'
 import * as ns from './ns'
 import contextTypes from './contextTypes'
@@ -10,6 +10,7 @@ export default class JssProvider extends Component {
     ...propTypes,
     generateClassName: func,
     classNamePrefix: string,
+    disableStylesGeneration: bool,
     children: node.isRequired
   }
 
@@ -22,7 +23,9 @@ export default class JssProvider extends Component {
   // 2. If value was passed, we set it on the child context.
   // 3. If value was not passed, we proxy parent context (default context behaviour).
   getChildContext() {
-    const {registry, classNamePrefix, jss: localJss, generateClassName} = this.props
+    const {
+      registry, classNamePrefix, jss: localJss, generateClassName, disableStylesGeneration
+    } = this.props
     const sheetOptions = this.context[ns.sheetOptions] || {}
     const context = {[ns.sheetOptions]: sheetOptions}
 
@@ -60,6 +63,9 @@ export default class JssProvider extends Component {
 
     if (classNamePrefix) sheetOptions.classNamePrefix = classNamePrefix
     if (localJss) context[ns.jss] = localJss
+    if (disableStylesGeneration !== undefined) {
+      sheetOptions.disableStylesGeneration = disableStylesGeneration
+    }
 
     return context
   }

--- a/src/JssProvider.test.js
+++ b/src/JssProvider.test.js
@@ -195,6 +195,46 @@ describe('JssProvider', () => {
         `)
       })
     })
+
+    describe('disableStylesGeneration prop', () => {
+      it('should forward from context', () => {
+        const generateClassName = () => 'a'
+        const registry = new SheetsRegistry()
+        const MyComponent = injectSheet({a: {color: 'red'}})()
+
+        render(
+          <JssProvider registry={registry} disableStylesGeneration>
+            <JssProvider generateClassName={generateClassName}>
+              <MyComponent />
+            </JssProvider>
+          </JssProvider>,
+          node
+        )
+
+        expect(registry.toString()).to.be('')
+      })
+
+      it('should overwrite over child props', () => {
+        const generateClassName = () => 'a'
+        const registry = new SheetsRegistry()
+        const MyComponent = injectSheet({a: {color: 'red'}})()
+
+        render(
+          <JssProvider registry={registry} disableStylesGeneration>
+            <JssProvider generateClassName={generateClassName} disableStylesGeneration={false}>
+              <MyComponent />
+            </JssProvider>
+          </JssProvider>,
+          node
+        )
+
+        expect(registry.toString()).to.be(stripIndent`
+          .a {
+            color: red;
+          }
+        `)
+      })
+    })
   })
 
   describe('JssProvider in a stateful component', () => {

--- a/src/createHoc.js
+++ b/src/createHoc.js
@@ -140,6 +140,10 @@ export default (stylesOrCreator, InnerComponent, options = {}) => {
 
     createState({theme, dynamicSheet}, {classes: userClasses}) {
       const contextSheetOptions = this.context[ns.sheetOptions]
+      if (contextSheetOptions && contextSheetOptions.disableStylesGeneration) {
+        return {theme, dynamicSheet, classes: {}}
+      }
+
       let classNamePrefix = defaultClassNamePrefix
       let staticSheet = this.manager.get(theme)
       let dynamicStyles
@@ -180,6 +184,10 @@ export default (stylesOrCreator, InnerComponent, options = {}) => {
     }
 
     manage({theme, dynamicSheet}) {
+      const contextSheetOptions = this.context[ns.sheetOptions]
+      if (contextSheetOptions && contextSheetOptions.disableStylesGeneration) {
+        return
+      }
       const registry = this.context[ns.sheetsRegistry]
 
       const staticSheet = this.manager.manage(theme)


### PR DESCRIPTION
For traversing the React tree outside of the HTML rendering, you should add `disableStylesGeneration` property.

```javascript
import * as React from 'react';
import * as ReactDOM from 'react-dom';
import bootstrapper from 'react-async-bootstrapper';

import { JssProvider } from 'react-jss';
import MyApp from './MyApp';

const App = ({ disableStylesGeneration }) => (
  <JssProvider disableStylesGeneration>
    <MyApp />
  </JssProvider>
);

async function main() {
  await bootstrapper(<App disableStylesGeneration />);
  ReactDOM.render(<App />, document.getElementById('root'));
}

main();

```