### PR TITLE
Fix incorrect build status badge URL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # JSS integration with React
 
 [![Gitter](https://badges.gitter.im/JoinChat.svg)](https://gitter.im/cssinjs/lobby)
-[![Build Status](https://travis-ci.org/cssinjs/react-kss.svg?branch=master)](https://travis-ci.org/cssinjs/react-jss)
+[![Build Status](https://travis-ci.org/cssinjs/react-jss.svg?branch=master)](https://travis-ci.org/cssinjs/react-jss)
 
 React-JSS provides components for [JSS](https://github.com/cssinjs/jss) as a layer of abstraction. JSS and the [default preset](https://github.com/cssinjs/jss-preset-default) are already built in! Try it out in the [playground](https://codesandbox.io/s/j3l06yyqpw).
 


### PR DESCRIPTION
This is trivial but I’m a new org member, so thought it might be rude to push anything to master without a review.