### PR TITLE
Fix `Cannot read property 'detach' of undefined`

### DIFF
--- a/src/createHoc.js
+++ b/src/createHoc.js
@@ -121,7 +121,7 @@ export default (stylesOrCreator, InnerComponent, options = {}) => {
 
     componentDidUpdate(prevProps, prevState) {
       // We remove previous dynamicSheet only after new one was created to avoid FOUC.
-      if (prevState.dynamicSheet !== this.state.dynamicSheet) {
+      if (prevState.dynamicSheet !== this.state.dynamicSheet && prevState.dynamicSheet) {
         this.jss.removeStyleSheet(prevState.dynamicSheet)
       }
     }


### PR DESCRIPTION
The only reason `react-jss-hmr` patches `componentDidUpdate()` is to stop this code from throwing when a dynamic sheet gets added via HMR. 

If we add this check, I can merge cssinjs/react-jss-hmr#3 and the code over there will be simpler.

On the other hand, this check is completely unnecessary except when `react-jss-hmr` is being used.